### PR TITLE
Define xrange() for Python 3

### DIFF
--- a/Tuchart/Graph.py
+++ b/Tuchart/Graph.py
@@ -5,6 +5,11 @@ import re
 import tushare as ts
 import time
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 def calculateMa(data, Daycount):
     sum = 0
     result = list( 0 for x in data)#used to calculate ma. Might be deprecated for future versions

--- a/build/lib/Tuchart/Graph.py
+++ b/build/lib/Tuchart/Graph.py
@@ -5,6 +5,11 @@ import re
 import tushare as ts
 import time
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 def calculateMa(data, Daycount):
     sum = 0
     result = list( 0 for x in data)#used to calculate ma. Might be deprecated for future versions


### PR DESCRIPTION
`xrange()`was removed from Python 3.  It is called on line 82.